### PR TITLE
cleanup/perf: simplify a few expressions

### DIFF
--- a/lib/general.js
+++ b/lib/general.js
@@ -22,9 +22,7 @@ export default function general (ret, part, value, l10n) {
     let exp = v
       ? Math.floor(Math.log10(v))
       : 0;
-    let n = (exp < 0)
-      ? v * (10 ** -exp)
-      : v / (10 ** exp);
+    let n = v * (10 ** -exp);
     if (n === 10) {
       n = 1;
       exp++;

--- a/lib/numdec.js
+++ b/lib/numdec.js
@@ -28,12 +28,7 @@ export default function numdec (value, incl_sign = true) {
     // B: this has turned out to be much faster than all pure math
     // based solutions I was able to come up with ¯\_(ツ)_/¯
     const n = String(
-      round(
-        (intSize < 0)
-          ? v * (10 ** -intSize)
-          : v / (10 ** intSize),
-        15
-      )
+      round(v * (10 ** -intSize), 15)
     );
     let f = n.length;
     let z = true;

--- a/lib/round.js
+++ b/lib/round.js
@@ -7,7 +7,7 @@ export default function round (value, places) {
     return -round(-value, places);
   }
   if (places) {
-    const p = 10 ** (places || 0) || 1;
+    const p = 10 ** (places) || 1;
     return round(value * p, 0) / p;
   }
   return Math.round(value);

--- a/lib/runPart.js
+++ b/lib/runPart.js
@@ -69,7 +69,7 @@ export function runPart (value, part, opts, l10n_) {
       const tempValue = round(v * scale, part.frac_max) / scale;
       exp = getExponent(tempValue, part.int_max);
     }
-    v = v / (10 ** exp);
+    v = v * (10 ** -exp);
     value = (value < 0) ? -v : v;
     mantissa += Math.abs(exp);
   }


### PR DESCRIPTION
Simplify/optimize a few expressions a tiny bit, based on these facts:

* dividing by `X ** exp` is the same as multiplying by `X ** -exp`
* multiplication is a little faster than division (at least on the metal — with transpilation and a VM underneath you, who knows?)
* inside `if (places)`, the expression `places || 0` is equivalent to `places`